### PR TITLE
feat!(web): restrict clients that can connect to mirakc (#23)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,7 +1014,9 @@ version = "0.4.0"
 dependencies = [
  "actix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-files 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-http 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-rt 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-service 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT OR Apache-2.0"
 actix = "0.9"
 actix-files = "0.2"
 actix-rt = "1.0"
+actix-service = "1.0"
 actix-web = "2.0"
 bytes = "0.5"
 cfg-if = "0.1"
@@ -33,6 +34,7 @@ shell-words = "0.1"
 tokio = { version = "0.2", features = ["full"] }
 
 [dev-dependencies]
+actix-http = "1.0"
 matches = "0.1"
 tokio-test = "0.2"
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,6 +23,8 @@ pub enum Error {
     ProgramNotFound,
     #[fail(display = "Session not found")]
     SessionNotFound,
+    #[fail(display = "Access denied")]
+    AccessDenied,
     #[fail(display = "Command failed: {}", 0)]
     CommandFailed(command_util::Error),
     #[fail(display = "std::io::error: {}", 0)]


### PR DESCRIPTION
BREAKING CHANGE: only clients in private networks can connect to mirakc.

INCOMPATIBILITY: unlike Mirakurun, mirakc takes no account of HTTP `Forwarded`
                 and `X-Forwraded-For` headers.

TODO: use IpAddr::is_global() once it's available in the stable release.